### PR TITLE
Run all PRs against ponyc release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,9 @@ workflows:
           context: org-global
       - debug-vs-ponyc-release-openssl-098:
           context: org-global
-      # temporarily against master until a bug is fixed in next release of ponyc
-      - release-vs-ponyc-master-openssl-110:
+      - release-vs-ponyc-release-openssl-110:
           context: org-global
-      - debug-vs-ponyc-master-openssl-110:
+      - debug-vs-ponyc-release-openssl-110:
           context: org-global
 
   nightly:


### PR DESCRIPTION
Previously, a couple were being run against master instead of release.
This was due to a bug in 0.29.0 that has been fixed on master. With
the release of Pony 0.30.0, we can go back to running against the
release image.

Closes #7